### PR TITLE
[IMP] remove unaccent in field

### DIFF
--- a/odoo_module_migrate/migration_scripts/migrate_170_180.py
+++ b/odoo_module_migrate/migration_scripts/migrate_170_180.py
@@ -100,8 +100,35 @@ def replace_user_has_groups(
             logger.error(f"Error processing file {file}: {str(e)}")
 
 
+def replace_unaccent_parameter(
+    logger, module_path, module_name, manifest_path, migration_steps, tools
+):
+    files_to_process = tools.get_files(module_path, (".py",))
+    replaces = {
+        # Handle multiline with unaccent=False or unaccent=True
+        r"(?s)fields\.(Char|Text|Html|Properties)\(\s*unaccent\s*=\s*(False|True)\s*,?\s*\)": r"fields.\1()",
+        # Handle when unaccent=False or unaccent=True is the first parameter
+        r"(?s)fields\.(Char|Text|Html|Properties)\(\s*unaccent\s*=\s*(False|True)\s*,\s*([^)]+?)\)": r"fields.\1(\3)",
+        # Handle when unaccent=False or unaccent=True is between other parameters
+        r"(?s)fields\.(Char|Text|Html|Properties)\(([^)]+?),\s*unaccent\s*=\s*(False|True)\s*,\s*([^)]+?)\)": r"fields.\1(\2, \4)",
+        # Handle when unaccent=False or unaccent=True is the last parameter
+        r"(?s)fields\.(Char|Text|Html|Properties)\(([^)]+?),\s*unaccent\s*=\s*(False|True)\s*\)": r"fields.\1(\2)",
+    }
+
+    for file in files_to_process:
+        try:
+            tools._replace_in_file(
+                file,
+                replaces,
+                log_message=f"[18.0] Removed deprecated unaccent=False parameter in file: {file}",
+            )
+        except Exception as e:
+            logger.error(f"Error processing file {file}: {str(e)}")
+
+
 class MigrationScript(BaseMigrationScript):
     _GLOBAL_FUNCTIONS = [
+        replace_unaccent_parameter,
         replace_tree_with_list_in_views,
         replace_chatter_blocks,
         replace_user_has_groups,

--- a/tests/data_result/module_170_180/models/res_partner.py
+++ b/tests/data_result/module_170_180/models/res_partner.py
@@ -5,6 +5,16 @@ class ResPartner(models.Model):
     _inherit = "res.partner"
 
     test_field_1 = fields.Boolean()
+    test_unaccent = fields.Char(string="test_unaccent", default="test")
+    test_unaccent_only = fields.Char()
+    test_unaccent_only_html = fields.Html()
+    test_unaccent_multiline = fields.Char(string="test_unaccent", default="test")
+    test_unaccent_only_multiline = fields.Text()
+    test_unaccent_true = fields.Char(string="test_unaccent", default="test")
+    test_unaccent_true_only = fields.Char()
+    test_unaccent_true_only_html = fields.Html()
+    test_unaccent_true_multiline = fields.Char(string="test_unaccent", default="test")
+    test_unaccent_true_only_multiline = fields.Text()
 
     def example_method(self):
         self.env.ref('module_name.tree_view').write({'view_mode': 'list'})

--- a/tests/data_template/module_170/models/res_partner.py
+++ b/tests/data_template/module_170/models/res_partner.py
@@ -5,6 +5,24 @@ class ResPartner(models.Model):
     _inherit = "res.partner"
 
     test_field_1 = fields.Boolean()
+    test_unaccent = fields.Char(string="test_unaccent", unaccent=False, default="test")
+    test_unaccent_only = fields.Char(unaccent=False)
+    test_unaccent_only_html = fields.Html(unaccent=False)
+    test_unaccent_multiline = fields.Char(string="test_unaccent",
+                                          unaccent=False,
+                                          default="test")
+    test_unaccent_only_multiline = fields.Text(
+        unaccent=False,
+    )
+    test_unaccent_true = fields.Char(string="test_unaccent", unaccent=True, default="test")
+    test_unaccent_true_only = fields.Char(unaccent=True)
+    test_unaccent_true_only_html = fields.Html(unaccent=True)
+    test_unaccent_true_multiline = fields.Char(string="test_unaccent",
+                                          unaccent=True,
+                                          default="test")
+    test_unaccent_true_only_multiline = fields.Text(
+        unaccent=True,
+    )
 
     def example_method(self):
         self.env.ref('module_name.tree_view').write({'view_mode': 'tree'})


### PR DESCRIPTION
for more information: `https://github.com/odoo/odoo/pull/139568`

we remove `unaccent=False` in field declaration

example 

```
// before
test_unaccent = fields.Char(string="test_unaccent", unaccent=False, default="test")
// after
test_unaccent = fields.Char(string="test_unaccent", default="test")
```